### PR TITLE
feat: Optimize Multi-Platform Docker Build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,21 @@
-node_modules/
-dist/
+# Ignore all and then selectivly allow
+**/*
 
-frontend/node_modules/
-frontend/src/tailwind/tailwind.generated.css
+# api
+!package.json
+!package-lock.json
+!nest-cli.json
+!tsconfig.build.json
+!tsconfig.json
 
-charts/
+!src/**/*
+
+# frontend
+!frontend/.env.production
+!frontend/package.json
+!frontend/package-lock.json
+!frontend/postcss.config.js
+!frontend/tailwind.config.js
+!frontend/tsconfig.json
+!frontend/src/**/*
+!frontend/public/**/*

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Install semantic-release
-        run: npm install -g --legacy-peer-deps semantic-release @semantic-release/git @semantic-release/changelog @semantic-release/exec semantic-release-docker
+        run: npm install -g --legacy-peer-deps semantic-release @semantic-release/git @semantic-release/changelog @semantic-release/exec
 
       - name: Release
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - alpha
 jobs:
   tests:
     uses: ./.github/workflows/ci.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,8 @@ LABEL org.opencontainers.image.title="listory" \
 
 WORKDIR /app
 
+ENV NODE_ENV=production
+
 COPY package.json /app/
 COPY package-lock.json /app/
 RUN --mount=type=cache,target=/home/root/.npm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1.5
+
 FROM scratch as ignore
 
 WORKDIR /listory
@@ -17,7 +19,9 @@ FROM common as build-api
 LABEL stage="build-api"
 
 COPY *.json /app/
-RUN npm ci
+RUN --mount=type=cache,target=/home/root/.npm \
+  npm set cache /usr/src/app/.npm && \
+  npm ci
 
 COPY src/ /app/src/
 RUN NODE_ENV=production npm run build
@@ -33,7 +37,10 @@ ARG VERSION=unknown
 WORKDIR /app/frontend
 
 COPY frontend/package*.json /app/frontend/
-RUN npm ci
+RUN --mount=type=cache,target=/home/root/.npm \
+  npm set cache /usr/src/app/.npm && \
+  npm ci
+
 
 COPY frontend/ /app/frontend/
 RUN NODE_ENV=production npm run build
@@ -55,7 +62,9 @@ WORKDIR /app
 
 COPY package.json /app/
 COPY package-lock.json /app/
-RUN npm ci --omit=dev
+RUN --mount=type=cache,target=/home/root/.npm \
+  npm set cache /usr/src/app/.npm && \
+  npm ci --omit=dev
 
 COPY --from=build-api /app/dist/ /app/dist/
 COPY --from=build-frontend /app/frontend/build /app/static/

--- a/hack/build-docker-image.sh
+++ b/hack/build-docker-image.sh
@@ -11,7 +11,7 @@ REPO="apricote/listory"
 PLATFORMS="--platform=linux/amd64,linux/arm64"
 TAGS="--tag ${REPO}:${VERSION} --tag ${REPO}:latest"
 ARGS="--build-arg VERSION=${VERSION} --build-arg GIT_COMMIT=`git rev-parse HEAD`"
-CACHE="--cache-from=type=registry,ref=${REPO}:buildcache --cache-to=type=registry,ref=${REPO}:buildcache"
+CACHE="--cache-from=type=registry,ref=${REPO}:buildcache --cache-to=type=registry,ref=${REPO}:buildcache,mode=max"
 
 
 # We "build" the image twice, once in "prepare" and then again in "publish" stage:


### PR DESCRIPTION
Implements #265

This adds multiple optimizations to the Docker/Buildkit build process. See individual commits for details.

For a performance comparison of the CI pipeline, release 1.24.2 took (excl. tests) 31 minutes, while 1.25.0-alpha.1 took 10 minutes.

I think 10 minutes is okay for now and reasonably close to 2x the previous ~3 minutes.