### PR TITLE
chore(deps): bump grafana/tempo to v2.1.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -173,7 +173,7 @@ services:
 
   tempo:
     profiles: ["observability"]
-    image: grafana/tempo:main-53d34ee-amd64
+    image: grafana/tempo:2.1.1
     command: ["-config.file=/etc/tempo.yaml"]
     volumes:
       - ./observability/tempo/tempo.yaml:/etc/tempo.yaml

--- a/observability/tempo/tempo.yaml
+++ b/observability/tempo/tempo.yaml
@@ -24,16 +24,10 @@ storage:
     backend: local # backend configuration to use
     block:
       bloom_filter_false_positive: .05 # bloom filter false positive rate.  lower values create larger filters but fewer false positives
-      index_downsample_bytes: 1000 # number of bytes per index record
-      encoding: zstd # block encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd
     wal:
       path: /tmp/tempo/wal # where to store the the wal locally
-      encoding: none # wal encoding/compression.  options: none, gzip, lz4-64k, lz4-256k, lz4-1M, lz4, snappy, zstd
     local:
       path: /tmp/tempo/blocks
     pool:
       max_workers: 100 # the worker pool mainly drives querying, but is also used for polling the blocklist
       queue_depth: 10000
-
-# Enable search functionality
-search_enabled: true


### PR DESCRIPTION
Cleans up the preview release of tempo from 515c80a6e3009b1fe16623ba12b9fc17b837051e.

Everything is working with v2.1.1 as far as i could tell.