### PR TITLE
fix: missing import for @hapi/joi

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "@nestjs/testing": "9.4.0",
     "@types/cookie-parser": "1.4.3",
     "@types/express": "4.17.17",
-    "@types/hapi__joi": "17.1.9",
     "@types/jest": "29.5.1",
     "@types/lodash": "^4.14.194",
     "@types/long": "4.0.2",

--- a/src/config/config.module.ts
+++ b/src/config/config.module.ts
@@ -1,6 +1,6 @@
-import * as Joi from "@hapi/joi";
 import { Module } from "@nestjs/common";
 import { ConfigModule as NestConfigModule } from "@nestjs/config";
+import * as Joi from "joi";
 
 @Module({
   imports: [


### PR DESCRIPTION
Replaced the module in the dependencies but not in actual usage