### PR TITLE
fix: no listens are being crawled

### DIFF
--- a/src/sources/scheduler.service.ts
+++ b/src/sources/scheduler.service.ts
@@ -37,7 +37,7 @@ export class SchedulerService implements OnApplicationBootstrap {
   }
 
   @Span()
-  // @CrawlerSupervisorJob.Handle()
+  @CrawlerSupervisorJob.Handle()
   async superviseImportJobs(): Promise<void> {
     this.logger.log("Starting crawler jobs");
     const userInfo = await this.spotifyService.getCrawlableUserInfo();


### PR DESCRIPTION
The supervisor job handler was accidentally disabled in a previous commit.